### PR TITLE
use mason

### DIFF
--- a/lua/config/mason-cfg.lua
+++ b/lua/config/mason-cfg.lua
@@ -3,4 +3,4 @@ if not status_ok then
     return
 end
 
-m.setup()
+m.setup({})


### PR DESCRIPTION
- Working mason config. Removes nvim-lsp-installer
- Using mason plugin
- Updated setup call
